### PR TITLE
[feat] 로그인한 유저 정보 전역으로 관리

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,3 +1,4 @@
+import AuthProvider from '@/context/AuthProvider';
 import GroupProvider from '@/context/GroupProvider';
 import TILProvider from '@/context/TILProvider';
 import Router from './Router';
@@ -11,11 +12,13 @@ function App() {
   return (
     <>
       <GlobalStyle />
-      <GroupProvider initialGroups={initialGroups}>
-        <TILProvider>
-          <Router />
-        </TILProvider>
-      </GroupProvider>
+      <AuthProvider>
+        <GroupProvider initialGroups={initialGroups}>
+          <TILProvider>
+            <Router />
+          </TILProvider>
+        </GroupProvider>
+      </AuthProvider>
     </>
   );
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,7 @@
 import AuthProvider from '@/context/AuthProvider';
 import GroupProvider from '@/context/GroupProvider';
 import TILProvider from '@/context/TILProvider';
-import Router from './Router';
+import Router from '@/Router';
 import GlobalStyle from './styles/globalStyle';
 import { getChannelList } from '@/api/channel';
 import { useAsync } from '@/hooks';

--- a/src/api/userSign.js
+++ b/src/api/userSign.js
@@ -1,11 +1,8 @@
 import { axiosInstance } from '@/api/core';
-import axios from 'axios';
-import { setItem, getItem, removeItem } from '@/utils/storage';
 
 export const postUserSignUp = async (data) => {
   try {
     const response = await axiosInstance.post('/signup', data);
-
     return response;
   } catch (error) {
     console.error(error);
@@ -15,11 +12,6 @@ export const postUserSignUp = async (data) => {
 export const postUserSignIn = async (data) => {
   try {
     const response = await axiosInstance.post('/login', data);
-    setItem('token', response.token);
-
-    // const { accessToken } = response.data;
-    // axios.defaults.headers.common['Authorization'] = `Bearer ${accessToken}`;
-
     return response;
   } catch (error) {
     console.error(error);
@@ -29,8 +21,6 @@ export const postUserSignIn = async (data) => {
 export const postUserSignOut = async () => {
   try {
     const response = await axiosInstance.post('/logout');
-    removeItem('token');
-
     return response;
   } catch (error) {
     console.error(error);

--- a/src/api/userSign.js
+++ b/src/api/userSign.js
@@ -15,6 +15,7 @@ export const postUserSignIn = async (data) => {
     return response;
   } catch (error) {
     console.error(error);
+    return { isFailed: true, errorMessage: '아이디 또는 비밀번호를 확인해주세요.' };
   }
 };
 

--- a/src/components/domain/Header/HeaderUserNav.jsx
+++ b/src/components/domain/Header/HeaderUserNav.jsx
@@ -3,33 +3,23 @@ import Button from '@/components/base/Button';
 import { COLOR } from '@/styles/color';
 import styled from '@emotion/styled';
 import { useNavigate } from 'react-router-dom';
-import { useEffect, useState } from 'react';
 import { postUserSignOut } from '@/api/userSign';
-import { getItem } from '@/utils/storage';
+import { useAuthContext } from '@/context/AuthProvider';
 
 const HeaderUserNav = () => {
   const navigate = useNavigate();
-  const [isLogined, setIsLogined] = useState(false);
+  const {
+    authState: { isLoggedIn },
+    onLogout,
+  } = useAuthContext();
 
   const signOut = async () => {
     await postUserSignOut();
-    setIsLogined(false);
+    onLogout();
     navigate('/');
   };
 
-  const refreshUserState = () => {
-    if (getItem('token')) {
-      return setIsLogined(true);
-    }
-
-    return setIsLogined(false);
-  };
-
-  useEffect(() => {
-    refreshUserState();
-  }, [getItem('token')]);
-
-  if (!isLogined) {
+  if (!isLoggedIn) {
     return (
       <StyledHeaderUserNav>
         <Button

--- a/src/context/AuthProvider.jsx
+++ b/src/context/AuthProvider.jsx
@@ -1,0 +1,37 @@
+import { createContext, useState, useContext } from 'react';
+import { setItem, getItem, removeItem } from '@/utils/storage';
+
+const AuthContext = createContext();
+export const useAuthContext = () => useContext(AuthContext);
+
+const AuthProvider = ({ children }) => {
+  const [authState, setAuthState] = useState({
+    isLoggedIn: getItem('token') ? true : false,
+    loggedUser: getItem('user'),
+    userToken: getItem('token'),
+  });
+
+  const onLogin = ({ user, token }) => {
+    setItem('user', user);
+    setItem('token', token);
+    setAuthState({
+      isLoggedIn: true,
+      loggedUser: user,
+      userToken: token,
+    });
+  };
+
+  const onLogout = () => {
+    removeItem('user');
+    removeItem('token');
+    setAuthState({
+      isLoggedIn: false,
+      loggedUser: {},
+      userToken: '',
+    });
+  };
+
+  return <AuthContext.Provider value={{ authState, onLogin, onLogout }}>{children}</AuthContext.Provider>;
+};
+
+export default AuthProvider;

--- a/src/pages/SignIn.jsx
+++ b/src/pages/SignIn.jsx
@@ -5,6 +5,7 @@ import { COLOR } from '@/styles/color';
 import styled from '@emotion/styled';
 import { useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useAuthContext } from '@/context/AuthProvider';
 
 const ERRORS = {
   EMAIL_EMPTY_ERROR: '이메일을 입력해 주세요',
@@ -20,6 +21,7 @@ const INPUT_NUMBER_LIMIT = {
 
 function SignIn() {
   const navigate = useNavigate();
+  const { onLogin } = useAuthContext();
 
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -42,8 +44,8 @@ function SignIn() {
     };
 
     setIsLoading(true);
-    await postUserSignIn(requestBody);
-
+    const data = await postUserSignIn(requestBody);
+    onLogin(data);
     alert('로그인');
     setIsLoading(false);
 

--- a/src/pages/SignIn.jsx
+++ b/src/pages/SignIn.jsx
@@ -45,10 +45,14 @@ function SignIn() {
 
     setIsLoading(true);
     const data = await postUserSignIn(requestBody);
-    onLogin(data);
-    alert('로그인');
     setIsLoading(false);
 
+    if (data.isFailed) {
+      alert(data.errorMessage);
+      return;
+    }
+    onLogin(data);
+    alert('로그인');
     navigate('/');
   };
 


### PR DESCRIPTION
## ⛓ 관련 이슈
- close #37

## 📝 작업 내용
- [x] 유저 정보, 토큰 전역 관리
- [x] 로그인시 에러 처리

## 📍 PR Point
- 로그인할 때 에러 처리가 안되어 있어서 비밀번호 틀리거나 하면 무한 로딩 돌길래 일단 간단하게 처리해놨습니다..
- 이제 로그인 여부, 토큰, 유저 정보 context로 가져올 수 있습니다.

