### PR TITLE
[feat] 그룹 가입 신청 api 연결

### DIFF
--- a/src/api/channel.js
+++ b/src/api/channel.js
@@ -2,8 +2,8 @@ import { axiosInstance, axiosAdminInstance } from './core/index';
 
 export const getChannelList = async () => {
   try {
-    const data = await axiosInstance.get(`/channels`);
-    const channelList = data.map((channel) => ({ ...channel, description: JSON.parse(channel.description) }));
+    const response = await axiosInstance.get(`/channels`);
+    const channelList = response.map((channel) => ({ ...channel, description: JSON.parse(channel.description) }));
     return channelList;
   } catch (error) {
     console.error(error);
@@ -12,8 +12,8 @@ export const getChannelList = async () => {
 
 export const getChannel = async (channelName) => {
   try {
-    const data = await axiosInstance.get(`/channels/${channelName}`);
-    return data;
+    const response = await axiosInstance.get(`/channels/${channelName}`);
+    return response;
   } catch (error) {
     console.error(error);
   }
@@ -25,6 +25,16 @@ export const createChannel = async (channelInfo) => {
     const createdChannel = { ...response, description: JSON.parse(response.description) };
 
     return createdChannel;
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+export const joinChannel = async (updateData) => {
+  try {
+    const response = await axiosAdminInstance.put(`/channels/update`, updateData);
+    const joinedChannel = { ...response, description: JSON.parse(response.description) };
+    return joinedChannel;
   } catch (error) {
     console.error(error);
   }

--- a/src/api/post.js
+++ b/src/api/post.js
@@ -3,8 +3,8 @@ import { axiosInstance } from './core';
 export const getPostListByChannel = async (channelId, offset, limit) => {
   try {
     const params = { offset, limit };
-    const data = await axiosInstance.get(`/posts/channel/${channelId}`, { params });
-    const postList = data.map((post) => ({ ...post, title: JSON.parse(post.title) }));
+    const response = await axiosInstance.get(`/posts/channel/${channelId}`, { params });
+    const postList = response.map((post) => ({ ...post, title: JSON.parse(post.title) }));
     return postList;
   } catch (error) {
     console.error(error);

--- a/src/components/domain/GroupItem/index.jsx
+++ b/src/components/domain/GroupItem/index.jsx
@@ -4,12 +4,16 @@ import { COLOR } from '@/styles/color';
 import { Divider } from '@/components/base';
 import { css } from '@emotion/react';
 import { useGroupContext } from '@/context/GroupProvider';
+import { useAuthContext } from '@/context/AuthProvider';
 
 function GroupItem({ group, isLastGroup }) {
   const { openedGroupId, setOpenedGroupId } = useGroupContext();
   const { _id, name, description } = group;
   const { master, tagList, intro } = description;
   const isOpened = openedGroupId === _id;
+  const {
+    authState: { loggedUser },
+  } = useAuthContext();
 
   return (
     <StyledGroupItem>
@@ -22,7 +26,7 @@ function GroupItem({ group, isLastGroup }) {
             {isOpened && (
               <StyledGroupIcons>
                 <Icon name='circle-info' />
-                <Icon name='gear' />
+                {master._id === loggedUser._id && <Icon name='gear' />}
               </StyledGroupIcons>
             )}
           </StyledGroupTitle>

--- a/src/components/domain/GroupItem/index.jsx
+++ b/src/components/domain/GroupItem/index.jsx
@@ -12,10 +12,11 @@ function GroupItem({ group, isLastGroup }) {
   const { openedGroupId, setOpenedGroupId } = useGroupContext();
   const { _id, name, description } = group;
   const { master, tagList, intro } = description;
-  const isOpened = openedGroupId === _id;
   const {
     authState: { loggedUser },
   } = useAuthContext();
+  const isOpened = openedGroupId === _id;
+  const isMaster = master._id === loggedUser._id;
 
   return (
     <StyledGroupItem>
@@ -35,7 +36,7 @@ function GroupItem({ group, isLastGroup }) {
             {isOpened && (
               <StyledGroupIcons>
                 <Icon name='circle-info' onClick={() => setGroupInfoModalVisible(true)} />
-                {master._id === loggedUser._id && <Icon name='gear' />}
+                {isMaster && <Icon name='gear' />}
               </StyledGroupIcons>
             )}
           </StyledGroupTitle>

--- a/src/components/domain/GroupList/index.jsx
+++ b/src/components/domain/GroupList/index.jsx
@@ -5,28 +5,37 @@ import { COLOR } from '@/styles/color';
 import { imgSearch } from '@/assets/images';
 import { Empty, Spinner } from '@/components/base';
 import TILList from '@/components/domain/TILList';
-import { Fragment } from 'react';
+import { Fragment, useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
+import { useAuthContext } from '@/context/AuthProvider';
 
 function GroupList() {
   const {
     groups: { value: groups, isLoading },
     openedGroupId,
   } = useGroupContext();
+  const {
+    authState: { loggedUser },
+  } = useAuthContext();
+  const [myGroupList, setMyGroupList] = useState([]);
+
+  useEffect(() => {
+    setMyGroupList(groups?.filter(({ description }) => description.member.some((el) => el._id === loggedUser._id)));
+  }, [groups]);
 
   return (
     <>
       {isLoading ? (
         <Spinner size={40} color={COLOR.TAG_COLOR[1]} />
       ) : (
-        <StyledGroupList isEmpty={!groups?.length}>
-          {groups?.length ? (
-            groups.map((group, i) => (
+        <StyledGroupList isEmpty={!myGroupList?.length}>
+          {myGroupList?.length ? (
+            myGroupList.map((group, i) => (
               <Fragment key={group._id}>
                 <Link to='/joinGroup' state={{ group }}>
                   그룹 가입하기
                 </Link>
-                <GroupItem group={group} isLastGroup={groups.length - 1 === i} />
+                <GroupItem group={group} isLastGroup={myGroupList.length - 1 === i} />
                 {openedGroupId === group._id && <TILList groupId={group._id} groupName={group.name} />}
               </Fragment>
             ))

--- a/src/components/domain/GroupList/index.jsx
+++ b/src/components/domain/GroupList/index.jsx
@@ -20,7 +20,12 @@ function GroupList() {
   const [myGroupList, setMyGroupList] = useState([]);
 
   useEffect(() => {
-    setMyGroupList(groups?.filter(({ description }) => description.member.some((el) => el._id === loggedUser._id)));
+    setMyGroupList(
+      groups?.filter(
+        ({ description }) =>
+          description.master._id === loggedUser._id || description.member.some((el) => el._id === loggedUser._id),
+      ),
+    );
   }, [groups]);
 
   return (

--- a/src/pages/JoinGroup.jsx
+++ b/src/pages/JoinGroup.jsx
@@ -4,6 +4,8 @@ import { COLOR } from '@/styles/color';
 import { Header, Image, Text, Icon } from '@/components/base';
 import { icCrown } from '@/assets/icons';
 import { imgUserAvatar } from '@/assets/images';
+import { useAuthContext } from '@/context/AuthProvider';
+import { joinChannel } from '@/api/channel';
 
 function JoinGroup() {
   const {
@@ -11,6 +13,15 @@ function JoinGroup() {
   } = useLocation();
   const { name, description } = group;
   const { master, tagList, intro, headCount, member } = description;
+  const {
+    authState: { loggedUser },
+  } = useAuthContext();
+
+  const handleJoinClick = () => {
+    member.push(loggedUser);
+    group.description = JSON.stringify(description);
+    joinChannel(group);
+  };
 
   return (
     <StyledJoinGroup>
@@ -44,7 +55,7 @@ function JoinGroup() {
           {intro}
         </Text>
       </StyledBody>
-      <StyledButton>그룹 가입하기</StyledButton>
+      <StyledButton onClick={() => handleJoinClick()}>그룹 가입하기</StyledButton>
     </StyledJoinGroup>
   );
 }

--- a/src/pages/JoinGroup.jsx
+++ b/src/pages/JoinGroup.jsx
@@ -44,8 +44,6 @@ function JoinGroup() {
     setGuideMessage('');
   }, []);
 
-  console.log(guideMessage);
-
   return (
     <StyledJoinGroup>
       <StyledHeader>

--- a/src/pages/JoinGroup.jsx
+++ b/src/pages/JoinGroup.jsx
@@ -23,10 +23,10 @@ function JoinGroup() {
   const [guideMessage, setGuideMessage] = useState('');
   const navigate = useNavigate();
 
-  const handleJoinClick = () => {
+  const handleJoinClick = async () => {
     member.push(loggedUser);
     group.description = JSON.stringify(description);
-    joinChannel(group);
+    await joinChannel(group);
     navigate('/myGroup');
   };
 

--- a/src/pages/JoinGroup.jsx
+++ b/src/pages/JoinGroup.jsx
@@ -1,4 +1,4 @@
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import styled from '@emotion/styled';
 import { COLOR } from '@/styles/color';
 import { Header, Image, Text, Icon } from '@/components/base';
@@ -21,11 +21,13 @@ function JoinGroup() {
     authState: { isLoggedIn, loggedUser },
   } = useAuthContext();
   const [guideMessage, setGuideMessage] = useState('');
+  const navigate = useNavigate();
 
   const handleJoinClick = () => {
     member.push(loggedUser);
     group.description = JSON.stringify(description);
     joinChannel(group);
+    navigate('/myGroup');
   };
 
   useEffect(() => {


### PR DESCRIPTION
## ⛓ 관련 이슈
- close #42 

## 📝 작업 내용
- [x] 그룹 가입 신청 api 연결 (바로 가입됨)
- [x] 그룹 가입 신청하기 버튼 비활성화 
  - 로그인 안 한 상황 / 이미 가입한 그룹일 경우 / 그룹의 정원이 모두 찬 경우
![스크린샷 2023-01-18 오전 12 49 10](https://user-images.githubusercontent.com/63948884/212954050-436164c4-3e9c-4ed9-8249-1a53193c3b13.png)
- [x] 기존 전체 그룹 리스트 불러오기 -> 내가 가입한 그룹 리스트 불러오기
- [x] 그룹 관리자만 그룹 관리 아이콘 보임

## 📍 PR Point
- 내 그룹 페이지에서 가입한 그룹 리스트 불러올 때 아래처럼 필터하는데 매번 이렇게 걸러줘야 하는 게 너무 비효율적인 것 같습니다. 
user 데이터에서 가입한 그룹 리스트를 가지고 있고, 그걸 불러오는 게 더 나을 것 같은데 어떻게 생각하시나요?
``` jsx
  useEffect(() => {
    setMyGroupList(
      groups?.filter(
        ({ description }) =>
          description.master._id === loggedUser._id || description.member.some((el) => el._id === loggedUser._id),
      ),
    );
  }, [groups]);
```