### PR TITLE
[feat] TIL 보기 페이지 로그인 하지 않은 사용자 처리

### DIFF
--- a/src/api/post.js
+++ b/src/api/post.js
@@ -14,7 +14,14 @@ export const getPostListByChannel = async (channelId, offset, limit) => {
 export const getTIL = async (id) => {
   try {
     const response = await axiosInstance.get(`/posts/${id}`);
-    const parsedResponse = { ...response, title: JSON.parse(response.title) };
+    const parsedResponse = {
+      ...response,
+      title: JSON.parse(response.title),
+      channel: {
+        ...response.channel,
+        description: JSON.parse(response.channel.description),
+      },
+    };
 
     return parsedResponse;
   } catch (error) {

--- a/src/components/base/Icon/index.scss
+++ b/src/components/base/Icon/index.scss
@@ -1,5 +1,4 @@
 .heart {
-  cursor: pointer;
   background: linear-gradient(to top, #fba194, #f6416c);
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;

--- a/src/components/domain/AuthorNav/index.jsx
+++ b/src/components/domain/AuthorNav/index.jsx
@@ -1,0 +1,26 @@
+import { Button } from '@/components/base';
+import styled from '@emotion/styled';
+
+function AuthorNav({ onLeftButtonClick, onRightButtonClick, text = ['수정', '삭제'] }) {
+  return (
+    <StyledButtonContainer>
+      <Button as='span' style={{ backgroundColor: 'transparent', fontSize: '1.4rem' }} onClick={onLeftButtonClick}>
+        {text[0]}
+      </Button>
+      <Button as='span' style={{ backgroundColor: 'transparent', fontSize: '1.4rem' }} onClick={onRightButtonClick}>
+        {text[1]}
+      </Button>
+    </StyledButtonContainer>
+  );
+}
+export default AuthorNav;
+
+const StyledButtonContainer = styled.div`
+  display: flex;
+  gap: 1rem;
+  align-self: center;
+
+  & > span:hover {
+    text-decoration: underline;
+  }
+`;

--- a/src/components/domain/CommentItem/index.jsx
+++ b/src/components/domain/CommentItem/index.jsx
@@ -1,11 +1,13 @@
 import { deleteAlarm } from '@/api/alarm';
 import { imgDefaultAvatar } from '@/assets/images';
-import { Avatar, Button, Text, Textarea } from '@/components/base';
+import { Avatar, Text, Textarea } from '@/components/base';
+import AuthorNav from '@/components/domain/AuthorNav';
 import { useAuthContext } from '@/context/AuthProvider';
 import { useCommentContext } from '@/context/CommentProvider';
 import useInput from '@/hooks/useInput';
 import { COLOR } from '@/styles/color';
 import { convertDate } from '@/utils/date';
+import { isAuthor } from '@/utils/post';
 import { getItem, removeItem } from '@/utils/storage';
 import styled from '@emotion/styled';
 import { useState } from 'react';
@@ -55,6 +57,7 @@ function CommentItem({ comment }) {
 
   const toggleEditButtonClick = () => {
     setMode(mode === 'view' ? 'edit' : 'view');
+    commentInput.onChange(body);
   };
 
   return (
@@ -66,47 +69,21 @@ function CommentItem({ comment }) {
             {author.fullName}
           </Text>
         </StyledWriterInfoContainer>
-        {author._id !== loggedUser._id ? null : mode === 'view' ? (
-          <StyledButtonContainer>
-            <Button
-              as='span'
-              style={{ backgroundColor: 'transparent', fontSize: '1.4rem' }}
-              onClick={toggleEditButtonClick}>
-              수정
-            </Button>
-            <Button
-              as='span'
-              style={{ backgroundColor: 'transparent', fontSize: '1.4rem' }}
-              onClick={handleDeleteButtonClick}>
-              삭제
-            </Button>
-          </StyledButtonContainer>
+        {!isAuthor(author._id, loggedUser._id) ? null : mode === 'view' ? (
+          <AuthorNav onLeftButtonClick={toggleEditButtonClick} onRightButtonClick={handleDeleteButtonClick} />
         ) : (
-          <StyledButtonContainer>
-            <Button
-              as='span'
-              style={{ backgroundColor: 'transparent', fontSize: '1.4rem' }}
-              onClick={handleSubmitButtonClick}>
-              완료
-            </Button>
-            <Button
-              as='span'
-              style={{ backgroundColor: 'transparent', fontSize: '1.4rem' }}
-              onClick={toggleEditButtonClick}>
-              취소
-            </Button>
-          </StyledButtonContainer>
+          <AuthorNav
+            onLeftButtonClick={handleSubmitButtonClick}
+            onRightButtonClick={toggleEditButtonClick}
+            text={['완료', '취소']}
+          />
         )}
       </FlexContainer>
       <Text size={1.2} color={COLOR.DARK}>
         {writtenTime}
       </Text>
       <StyledCommentWrapper>
-        {author._id !== loggedUser._id ? (
-          <Text size={1.8} color={COLOR.DARK}>
-            {body}
-          </Text>
-        ) : mode === 'view' ? (
+        {!isAuthor(author._id, loggedUser._id) || mode === 'view' ? (
           <Text size={1.8} color={COLOR.DARK}>
             {body}
           </Text>

--- a/src/components/domain/CreateComment/index.jsx
+++ b/src/components/domain/CreateComment/index.jsx
@@ -31,12 +31,5 @@ function CreateComment({ comment, ableSubmit, onSubmit }) {
 export default CreateComment;
 
 const StyledButtonWrapper = styled.div`
-  display: flex;
-  gap: 1rem;
-
-  & > span:hover {
-    text-decoration: underline;
-  }
-
   align-self: flex-end;
 `;

--- a/src/components/domain/CreateComment/index.jsx
+++ b/src/components/domain/CreateComment/index.jsx
@@ -1,0 +1,42 @@
+import { Button, Textarea } from '@/components/base';
+import { COLOR } from '@/styles/color';
+import styled from '@emotion/styled';
+
+function CreateComment({ comment, ableSubmit, onSubmit }) {
+  return (
+    <>
+      <Textarea
+        defaultValue={comment.value}
+        placeholder='댓글을 입력하세요.'
+        max={300}
+        wrapperProps={{ style: { width: '100%' } }}
+        style={{ fontSize: '1.2rem', height: '16rem' }}
+        handleParentChange={comment.onChange}
+      />
+      <StyledButtonWrapper>
+        <Button
+          as='button'
+          disabled={!ableSubmit}
+          bgcolor={!ableSubmit ? COLOR.GRAY : COLOR.PRIMARY_BTN}
+          color={!ableSubmit ? COLOR.DARK : COLOR.WHITE}
+          style={{ fontSize: '2.2rem', padding: '1.3rem 7rem', borderRadius: '1rem', width: '100%' }}
+          onClick={onSubmit}>
+          작성
+        </Button>
+      </StyledButtonWrapper>
+    </>
+  );
+}
+
+export default CreateComment;
+
+const StyledButtonWrapper = styled.div`
+  display: flex;
+  gap: 1rem;
+
+  & > span:hover {
+    text-decoration: underline;
+  }
+
+  align-self: flex-end;
+`;

--- a/src/components/domain/FloatingLikeButton/index.jsx
+++ b/src/components/domain/FloatingLikeButton/index.jsx
@@ -1,0 +1,48 @@
+import { Icon, Text } from '@/components/base';
+import { useAuthContext } from '@/context/AuthProvider';
+import { COLOR } from '@/styles/color';
+import { checkIsEmptyObj } from '@/utils/validation';
+import styled from '@emotion/styled';
+
+function FloatingLikeButton({ likes, likeButtonRef, onClick }) {
+  const {
+    authState: { loggedUser },
+  } = useAuthContext();
+
+  return (
+    <StyledLikeButtonContainer
+      ref={likeButtonRef}
+      onClick={() => !checkIsEmptyObj(loggedUser) && onClick()}
+      disabled={checkIsEmptyObj(loggedUser)}>
+      <Icon
+        name='heart'
+        size={3}
+        type={likes.length && likes.filter((like) => like.user === loggedUser._id).length ? 'solid' : 'regular'}
+      />
+      <Text size={1.2}>{likes.length}</Text>
+    </StyledLikeButtonContainer>
+  );
+}
+
+export default FloatingLikeButton;
+
+const StyledLikeButtonContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+
+  position: fixed;
+  right: 6rem;
+  bottom: 6rem;
+  z-index: 2000;
+
+  width: 8rem;
+  height: 8rem;
+  border-radius: 50%;
+  cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
+
+  background-color: ${COLOR.WHITE};
+  box-shadow: 0.5rem 1rem 0.5rem rgba(0, 0, 0, 0.25);
+`;

--- a/src/context/AuthProvider.jsx
+++ b/src/context/AuthProvider.jsx
@@ -7,7 +7,7 @@ export const useAuthContext = () => useContext(AuthContext);
 const AuthProvider = ({ children }) => {
   const [authState, setAuthState] = useState({
     isLoggedIn: getItem('token') ? true : false,
-    loggedUser: getItem('user'),
+    loggedUser: getItem('user', {}),
     userToken: getItem('token'),
   });
 

--- a/src/pages/TIL.jsx
+++ b/src/pages/TIL.jsx
@@ -11,6 +11,7 @@ import { COLOR } from '@/styles/color';
 import { convertDate } from '@/utils/date';
 import { getItem, removeItem, setItem } from '@/utils/storage';
 import { checkAbleSubmit, checkIsEmptyObj } from '@/utils/validation';
+import { isMember } from '@/utils/group';
 import styled from '@emotion/styled';
 import { Viewer } from '@toast-ui/react-editor';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -137,9 +138,24 @@ function TIL() {
               />
               <Text size={1.2}>{likes.length}</Text>
             </StyledLikeButton>
-            <Header level={1} strong size={40} color={COLOR.DARK}>
-              📚 [{til.channel.name}]에 대한 TIL
-            </Header>
+            <StyledHeader>
+              <Header level={1} strong size={40} color={COLOR.DARK}>
+                📚 [{til.channel.name}]에 대한 TIL
+              </Header>
+              {!isMember(til.channel, loggedUser._id) && (
+                <>
+                  <Button
+                    as='button'
+                    bgcolor={COLOR.PRIMARY_BTN}
+                    color={COLOR.WHITE}
+                    style={{ fontSize: '2.2rem', padding: '1.3rem 3rem', borderRadius: '1rem' }}
+                    onClick={() => navigate('/joinGroup', { state: { group: til.channel } })}>
+                    그룹 가입하기
+                  </Button>
+                  <div className='hide'></div>
+                </>
+              )}
+            </StyledHeader>
             <StyledTitleWrapper>
               <Text size={3.2} weight={500}>
                 {til.title.title}
@@ -191,7 +207,6 @@ function TIL() {
                     bgcolor={!ableSubmit ? COLOR.GRAY : COLOR.PRIMARY_BTN}
                     color={!ableSubmit ? COLOR.DARK : COLOR.WHITE}
                     style={{ fontSize: '2.2rem', padding: '1.3rem 7rem', borderRadius: '1rem', width: '100%' }}
-                    round={+true}
                     onClick={handleSubmitButtonClick}>
                     작성
                   </Button>
@@ -228,7 +243,7 @@ const StyledTIL = styled.div`
   padding: 16rem 8rem 8rem 8rem;
 
   @media (max-width: 624px) {
-    padding: 16rem 4rem 8rem 4rem;
+    padding: 12rem 4rem 8rem 4rem;
   }
 
   background-color: ${COLOR.MY_GROUP_BG};
@@ -290,4 +305,22 @@ const StyledLikeButton = styled.div`
 
   background-color: ${COLOR.WHITE};
   box-shadow: 0.5rem 1rem 0.5rem rgba(0, 0, 0, 0.25);
+`;
+
+const StyledHeader = styled.div`
+  display: flex;
+  flex-direction: row-reverse;
+  justify-content: space-between;
+
+  flex-wrap: wrap;
+  gap: 4rem 2rem;
+
+  & > h1 {
+    flex: 1 1 auto;
+    order: 1;
+  }
+
+  .hide {
+    visibility: collapse;
+  }
 `;

--- a/src/pages/TIL.jsx
+++ b/src/pages/TIL.jsx
@@ -1,6 +1,7 @@
 import { createAlarm, deleteAlarm } from '@/api/alarm';
 import { imgDefaultAvatar } from '@/assets/images';
 import { Avatar, Button, Divider, Header, Tag, Text } from '@/components/base';
+import AuthorNav from '@/components/domain/AuthorNav';
 import CommentList from '@/components/domain/CommentList';
 import CreateComment from '@/components/domain/CreateComment';
 import FloatingLikeButton from '@/components/domain/FloatingLikeButton';
@@ -12,13 +13,13 @@ import useInput from '@/hooks/useInput';
 import { COLOR } from '@/styles/color';
 import { convertDate } from '@/utils/date';
 import { isMember } from '@/utils/group';
+import { isAuthor } from '@/utils/post';
 import { getItem, removeItem, setItem } from '@/utils/storage';
 import { checkAbleSubmit, checkIsEmptyObj } from '@/utils/validation';
-import { isAuthor } from '@/utils/post';
 import styled from '@emotion/styled';
 import { Viewer } from '@toast-ui/react-editor';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Link, useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 
 function TIL() {
   const {
@@ -162,19 +163,10 @@ function TIL() {
                 </Text>
               </StyledWriterInfoContainer>
               {isAuthor(til.author._id, loggedUser._id) && (
-                <StyledButtonContainer>
-                  <Link to={`/updateTIL/${til._id}`} state={{ til }}>
-                    <Button as='span' style={{ backgroundColor: 'transparent', fontSize: '1.4rem' }}>
-                      수정
-                    </Button>
-                  </Link>
-                  <Button
-                    as='span'
-                    style={{ backgroundColor: 'transparent', fontSize: '1.4rem' }}
-                    onClick={handleDeleteButtonClick}>
-                    삭제
-                  </Button>
-                </StyledButtonContainer>
+                <AuthorNav
+                  onLeftButtonClick={() => navigate(`/updateTIL/${til._id}`, { state: { til } })}
+                  onRightButtonClick={handleDeleteButtonClick}
+                />
               )}
             </StyledFlexContainer>
             <Text size={1.4} color={COLOR.DARK}>
@@ -256,27 +248,6 @@ const StyledViewerWrapper = styled.div`
 
 const StyledCommentListWrapper = styled.div`
   margin-top: ${({ marginTop }) => marginTop};
-`;
-
-const StyledLikeButton = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 0.5rem;
-
-  position: fixed;
-  right: 6rem;
-  bottom: 6rem;
-  z-index: 2000;
-
-  width: 8rem;
-  height: 8rem;
-  border-radius: 50%;
-  cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
-
-  background-color: ${COLOR.WHITE};
-  box-shadow: 0.5rem 1rem 0.5rem rgba(0, 0, 0, 0.25);
 `;
 
 const StyledHeader = styled.div`

--- a/src/utils/group.js
+++ b/src/utils/group.js
@@ -1,0 +1,4 @@
+export const isMember = (group, id) => {
+  const member = group.description.member.find((memberId) => memberId === id);
+  return member && member.length;
+};

--- a/src/utils/post.js
+++ b/src/utils/post.js
@@ -1,0 +1,1 @@
+export const isAuthor = (authorId, id) => authorId === id;

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -1,3 +1,7 @@
 export function checkAbleSubmit(values) {
   return values.every((value) => value !== 0);
 }
+
+export function checkIsEmptyObj(obj) {
+  return obj.constructor === Object && Object.keys(obj).length === 0;
+}

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -3,5 +3,5 @@ export function checkAbleSubmit(values) {
 }
 
 export function checkIsEmptyObj(obj) {
-  return obj.constructor === Object && Object.keys(obj).length === 0;
+  return typeof obj === 'undefined' || (obj.constructor === Object && Object.keys(obj).length === 0);
 }


### PR DESCRIPTION
## ⛓ 관련 이슈
- close #84 

## 📝 작업 내용
- [x] TIL 보기 페이지 이동 시 auth 확인 후 disable 처리
- [x] 그룹 가입 신청 페이지 라우팅 버튼 구현
- [x] 자잘한 리팩터링

## 📍 PR Point
- 간신히 200자인데 더 줄일 방법이 있을지...

## 📷 스크린샷
- 그룹원이 아닌 유저에게 보여지는 화면
<img width="1235" alt="스크린샷 2023-02-02 오후 11 04 26" src="https://user-images.githubusercontent.com/34560965/216346185-10c1eb88-4a20-4566-be32-77b33258bfb4.png">
<img width="453" alt="스크린샷 2023-02-02 오후 11 04 43" src="https://user-images.githubusercontent.com/34560965/216346191-3cbc39c6-e3c5-4010-ad6d-72d02e17dfcf.png">
- 로그인 하지 않은 유저에게 보여지는 화면
<img width="432" alt="스크린샷 2023-02-02 오후 11 05 11" src="https://user-images.githubusercontent.com/34560965/216346195-009b50ad-c245-489a-a2b5-696452ca0ec9.png">