### PR TITLE
[feat] 검색 필터 드롭다운 닫기 이벤트 추가

### DIFF
--- a/src/components/domain/TemplateHeader/SearchBar.jsx
+++ b/src/components/domain/TemplateHeader/SearchBar.jsx
@@ -23,6 +23,18 @@ const SearchBar = () => {
     if (dropdown) setFilterValue(e.target.innerText);
   };
 
+  const onKeyDownEsc = (e) => {
+    if (dropdown === false) return;
+    if (e.key === 'Escape') {
+      setDropdown(false);
+    }
+  };
+
+  const onBlurDropDown = (e) => {
+    if (dropdown === false) return;
+    setDropdown(false);
+  };
+
   const handleGroupSearch = async () => {
     if (searchValue.length < SEARCH_VALUE_LENGTH_MIN) return alert(SEARCH_ERROR.INPUT_VALUE_LENGTH_MIN);
 
@@ -39,12 +51,17 @@ const SearchBar = () => {
 
   return (
     <StyledHeaderSearchBar>
-      <StyledDropdownTrigger onClick={handleDropdown}>{filterValue}</StyledDropdownTrigger>
+      <StyledDropdownTrigger
+        onClick={(e) => handleDropdown(e)}
+        onKeyDown={(e) => onKeyDownEsc(e)}
+        onBlur={(e) => onBlurDropDown(e)}>
+        {filterValue}
+      </StyledDropdownTrigger>
       {dropdown && (
         <StyledDropdownUl>
           {FILLTER_OPTIONS.map((option, index) => (
             <li key={index}>
-              <button value={option} onClick={handleDropdown} style={{ color: COLOR.DARK }}>
+              <button value={option} onMouseDown={(e) => handleDropdown(e)} style={{ color: COLOR.DARK }}>
                 {option}
               </button>
             </li>

--- a/src/components/domain/TemplateHeader/SearchBar.jsx
+++ b/src/components/domain/TemplateHeader/SearchBar.jsx
@@ -139,7 +139,7 @@ const StyledDropdownUl = styled.ul`
     color: ${COLOR.DARK};
   }
 
-  &> li > button: hover {
+  & > li > button:hover {
     background-color: ${COLOR.LIGHTGRAY};
   }
 `;

--- a/src/components/domain/TemplateHeader/SearchBar.jsx
+++ b/src/components/domain/TemplateHeader/SearchBar.jsx
@@ -24,14 +24,12 @@ const SearchBar = () => {
   };
 
   const onKeyDownEsc = (e) => {
-    if (dropdown === false) return;
     if (e.key === 'Escape') {
       setDropdown(false);
     }
   };
 
-  const onBlurDropDown = (e) => {
-    if (dropdown === false) return;
+  const onBlurDropDown = () => {
     setDropdown(false);
   };
 
@@ -52,16 +50,16 @@ const SearchBar = () => {
   return (
     <StyledHeaderSearchBar>
       <StyledDropdownTrigger
-        onClick={(e) => handleDropdown(e)}
-        onKeyDown={(e) => onKeyDownEsc(e)}
-        onBlur={(e) => onBlurDropDown(e)}>
+        onClick={handleDropdown}
+        onKeyDown={onKeyDownEsc}
+        onBlur={onBlurDropDown}>
         {filterValue}
       </StyledDropdownTrigger>
       {dropdown && (
         <StyledDropdownUl>
           {FILLTER_OPTIONS.map((option, index) => (
             <li key={index}>
-              <button value={option} onMouseDown={(e) => handleDropdown(e)} style={{ color: COLOR.DARK }}>
+              <button value={option} onMouseDown={handleDropdown} style={{ color: COLOR.DARK }}>
                 {option}
               </button>
             </li>


### PR DESCRIPTION
## ⛓ 관련 이슈
- close #88 

## 📝 작업 내용
- [x] 드롭다운 이외의 다른곳을 클릭했을때 닫히기.
- [x] esc누르면 닫히기

## 📍 PR Point
- 알게 된 것: onBlur, onMouseDown 이벤트 / 이벤트들의 작동 순서

onBlur 이벤트를 이용하여 드롭다운이 Focus를 잃으면, 즉 드롭다운 이외에 다른곳을 클릭하면 닫히게 구현하던 중
드롭다운의 li item을 눌러도 필터가 적용되지 않은채 드롭다운이 닫혀버리는 🐕 같은 상황이 발생했습니다.

거두절미하고 결론은 이벤트들에도 작동하는 우선순위가 있다는것인데,
현재 코드에 사용된 이벤트들을 작동되는 우선순위대로 나열하면
onMouseDown -> onBlur -> onClick 순서대로 작동합니다.

onMouseDown: li 클릭했을때 이벤트
onBlur: 드롭다운 이외의 다른곳을 클릭했을때(정확히는 드롭다운이 Focus를 잃었을 때) 이벤트
onClick: 드롭다운 열때 이벤트를
삽입해주어 구현되었습니다람ㅅ쥐


## 📷 스크린샷

https://user-images.githubusercontent.com/73218463/216387895-dd42fc8a-5517-440f-b831-d00e1663e40e.mov



