### PR TITLE
[feat] 페이지네이션 데이터 없을 경우 처리 

### DIFF
--- a/src/components/base/Pagination/index.jsx
+++ b/src/components/base/Pagination/index.jsx
@@ -12,6 +12,8 @@ const Pagination = ({ defaultPage, limit, total, onChange }) => {
     setPage(newPage);
   };
 
+  if (!totalPage) return null;
+
   return (
     <StyledPagination>
       <button onClick={() => handleChangePage(0)}>


### PR DESCRIPTION
## ⛓ 관련 이슈
- close #98 

## 📝 작업 내용
- [x] 데이터가 없을 경우에 아래와 같은 페이지 이동 버튼이 뜨지 않도록 얼리 리턴
<img width="100" alt="image" src="https://user-images.githubusercontent.com/63948884/216918355-26befb32-cb7e-4ec3-beda-5a676b5b4fb3.png">