### PR TITLE
[feat] 그룹 정보 변경 없을시 수정 버튼 비활성화

### DIFF
--- a/src/components/domain/ManageGroup/GroupDelete.jsx
+++ b/src/components/domain/ManageGroup/GroupDelete.jsx
@@ -1,23 +1,20 @@
 import { Header, Text } from '@/components/base';
+import { StyledButton, StyledGroupBox } from '@/pages/ManageGroup';
 import { COLOR } from '@/styles/color';
 import styled from '@emotion/styled';
-import { StyledGroupBox, StyledButton } from '@/pages/ManageGroup';
 
-const ALERT_MESSAGE = {
-  GROUP_DELETE: '그룹이 삭제되었습니다.',
-};
-
-const CONFIRM_MESSAGE = {
-  GROUP_DELETE: '정말 그룹을 삭제하시겠습니까?',
+const TOAST_MESSAGE = {
+  ALERT_GROUP_DELETE: '그룹이 삭제되었습니다.',
+  CONFIRM_GROUP_DELETE: '정말 그룹을 삭제하시겠습니까?',
 };
 
 function GroupDelete() {
   const handleDeleteClick = async () => {
-    if (!confirm(CONFIRM_MESSAGE.GROUP_DELETE)) return;
+    if (!confirm(TOAST_MESSAGE.CONFIRM_GROUP_DELETE)) return;
     await onDeleteGroup({
       id: group._id,
     });
-    addToast(ALERT_MESSAGE.GROUP_DELETE);
+    addToast(TOAST_MESSAGE.ALERT_GROUP_DELETE);
     navigate('/myGroup');
   };
 
@@ -46,22 +43,6 @@ const StyledGroupDelete = styled(StyledGroupBox)`
 
   & > p {
     padding: 1rem 0;
-  }
-`;
-
-const StyledButton = styled.button`
-  width: 10rem;
-  padding: 1rem;
-  border-radius: 0.6rem;
-
-  background-color: ${COLOR.PRIMARY_BTN};
-  text-align: center;
-  font-size: 1.8rem;
-  color: ${COLOR.WHITE};
-  cursor: pointer;
-
-  &:hover {
-    opacity: 0.9;
   }
 `;
 

--- a/src/components/domain/ManageGroup/GroupDelete.jsx
+++ b/src/components/domain/ManageGroup/GroupDelete.jsx
@@ -1,18 +1,25 @@
 import { Header, Text } from '@/components/base';
 import * as S from '@/components/domain/ManageGroup/styles';
+import { useGroupContext } from '@/context/GroupProvider';
+import { useToastContext } from '@/context/ToastProvider';
 import { COLOR } from '@/styles/color';
 import styled from '@emotion/styled';
+import { useNavigate } from 'react-router-dom';
 
 const TOAST_MESSAGE = {
   ALERT_GROUP_DELETE: '그룹이 삭제되었습니다.',
   CONFIRM_GROUP_DELETE: '정말 그룹을 삭제하시겠습니까?',
 };
 
-function GroupDelete() {
+function GroupDelete({ groupId }) {
+  const { onDeleteGroup } = useGroupContext();
+  const { addToast } = useToastContext();
+  const navigate = useNavigate();
+
   const handleDeleteClick = async () => {
     if (!confirm(TOAST_MESSAGE.CONFIRM_GROUP_DELETE)) return;
     await onDeleteGroup({
-      id: group._id,
+      id: groupId,
     });
     addToast(TOAST_MESSAGE.ALERT_GROUP_DELETE);
     navigate('/myGroup');

--- a/src/components/domain/ManageGroup/GroupDelete.jsx
+++ b/src/components/domain/ManageGroup/GroupDelete.jsx
@@ -1,5 +1,5 @@
 import { Header, Text } from '@/components/base';
-import { StyledButton, StyledGroupBox } from '@/pages/ManageGroup';
+import * as S from '@/components/domain/ManageGroup/styles';
 import { COLOR } from '@/styles/color';
 import styled from '@emotion/styled';
 
@@ -33,7 +33,7 @@ function GroupDelete() {
 
 export default GroupDelete;
 
-const StyledGroupDelete = styled(StyledGroupBox)`
+const StyledGroupDelete = styled(S.GroupBox)`
   background-color: ${COLOR.MY_GROUP_BOX_BG};
 
   & > h3 {
@@ -46,7 +46,7 @@ const StyledGroupDelete = styled(StyledGroupBox)`
   }
 `;
 
-const StyledDeleteButton = styled(StyledButton)`
+const StyledDeleteButton = styled(S.Button)`
   margin-top: 1rem;
   background-color: ${COLOR.RED_20};
 `;

--- a/src/components/domain/ManageGroup/GroupDelete.jsx
+++ b/src/components/domain/ManageGroup/GroupDelete.jsx
@@ -1,0 +1,71 @@
+import { Header, Text } from '@/components/base';
+import { COLOR } from '@/styles/color';
+import styled from '@emotion/styled';
+import { StyledGroupBox, StyledButton } from '@/pages/ManageGroup';
+
+const ALERT_MESSAGE = {
+  GROUP_DELETE: '그룹이 삭제되었습니다.',
+};
+
+const CONFIRM_MESSAGE = {
+  GROUP_DELETE: '정말 그룹을 삭제하시겠습니까?',
+};
+
+function GroupDelete() {
+  const handleDeleteClick = async () => {
+    if (!confirm(CONFIRM_MESSAGE.GROUP_DELETE)) return;
+    await onDeleteGroup({
+      id: group._id,
+    });
+    addToast(ALERT_MESSAGE.GROUP_DELETE);
+    navigate('/myGroup');
+  };
+
+  return (
+    <StyledGroupDelete>
+      <Header level={3} size={25}>
+        그룹 삭제
+      </Header>
+      <Text paragraph strong size={1.6}>
+        한번 그룹을 삭제하면 다시 되돌릴 수 없습니다.
+      </Text>
+      <StyledDeleteButton onClick={handleDeleteClick}>삭제</StyledDeleteButton>
+    </StyledGroupDelete>
+  );
+}
+
+export default GroupDelete;
+
+const StyledGroupDelete = styled(StyledGroupBox)`
+  background-color: ${COLOR.MY_GROUP_BOX_BG};
+
+  & > h3 {
+    border-bottom: 1px solid ${COLOR.RED_20};
+    color: ${COLOR.RED_20};
+  }
+
+  & > p {
+    padding: 1rem 0;
+  }
+`;
+
+const StyledButton = styled.button`
+  width: 10rem;
+  padding: 1rem;
+  border-radius: 0.6rem;
+
+  background-color: ${COLOR.PRIMARY_BTN};
+  text-align: center;
+  font-size: 1.8rem;
+  color: ${COLOR.WHITE};
+  cursor: pointer;
+
+  &:hover {
+    opacity: 0.9;
+  }
+`;
+
+const StyledDeleteButton = styled(StyledButton)`
+  margin-top: 1rem;
+  background-color: ${COLOR.RED_20};
+`;

--- a/src/components/domain/ManageGroup/ManageMember.jsx
+++ b/src/components/domain/ManageGroup/ManageMember.jsx
@@ -1,0 +1,102 @@
+import { Header, Icon, SearchBar } from '@/components/base';
+import { Member, MemberList } from '@/components/domain/groupInfo';
+import { useGroupContext } from '@/context/GroupProvider';
+import useInput from '@/hooks/useInput';
+import { COLOR } from '@/styles/color';
+import styled from '@emotion/styled';
+import { StyledGroupBox, StyledGroupInfo } from '@/pages/ManageGroup';
+
+const ALERT_MESSAGE = {
+  MEMBER_KICK: '이 강퇴 되었습니다.',
+  MASTER_DELEGATE: '이 방장이 되었습니다.',
+};
+
+const CONFIRM_MESSAGE = {
+  MEMBER_KICK: '을 정말 강퇴하시겠습니까?',
+  MASTER_DELEGATE: '에게 방장을 위임하시겠습니까?',
+};
+
+function ManageMember({ member }) {
+  const { onUpdateGroup } = useGroupContext();
+  const { value, onChange } = useInput('');
+
+  const handleKickClick = async (member) => {
+    const { fullName, _id } = member;
+    if (!confirm(`'${fullName}'님${CONFIRM_MESSAGE.MEMBER_KICK}`)) return false;
+    const data = {
+      ...group,
+      description: JSON.stringify({
+        ...group.description,
+        member: group.description.member.filter((memberId) => memberId !== _id),
+      }),
+    };
+    const updatedGroup = await onUpdateGroup(data);
+    setGroup(updatedGroup);
+    addToast(`'${fullName}님'${ALERT_MESSAGE.MEMBER_KICK}`);
+  };
+
+  const handleDelegateClick = async (member) => {
+    const { fullName, _id } = member;
+    if (!confirm(`'${fullName}'님${CONFIRM_MESSAGE.MASTER_DELEGATE}`)) return false;
+    const data = {
+      ...group,
+      description: JSON.stringify({
+        ...group.description,
+        master: _id,
+        member: [...group.description.member.filter((memberId) => memberId !== _id), group.description.master],
+      }),
+    };
+    const updatedGroup = await onUpdateGroup(data);
+    setGroup(updatedGroup);
+    addToast(`'${fullName}님'${ALERT_MESSAGE.MASTER_DELEGATE}`);
+    navigate('/myGroup');
+  };
+
+  return (
+    <StyledManageMember>
+      <Header level={3} size={25}>
+        그룹원 관리
+      </Header>
+      <StyledGroupInfo>
+        <SearchBar
+          placeholder='찾고 싶은 그룹원의 이름을 검색하세요.'
+          value={value}
+          onChange={onChange}
+          iconProps={{ size: 2, style: { color: `${COLOR.DARK}` } }}
+          style={{ fontSize: '1.8rem', fontWeight: 100, borderBottom: `0.1rem solid ${COLOR.GRAY}` }}
+        />
+      </StyledGroupInfo>
+      <MemberList>
+        {member &&
+          member
+            .filter(({ fullName }) => fullName.includes(value))
+            .map((member) => {
+              return (
+                <Member key={member._id} image={member.image} fullName={member.fullName}>
+                  <div>
+                    <Icon name='right-to-bracket' size={2} onClick={() => handleKickClick(member)} />
+                    <Icon name='crown' size={2} onClick={() => handleDelegateClick(member)} />
+                  </div>
+                </Member>
+              );
+            })}
+      </MemberList>
+    </StyledManageMember>
+  );
+}
+
+export default ManageMember;
+
+const StyledManageMember = styled(StyledGroupBox)`
+  & > div {
+    overflow-y: auto;
+  }
+
+  & i {
+    color: ${COLOR.PRIMARY_BTN};
+    &:hover {
+      color: ${COLOR.WHITE};
+      cursor: pointer;
+    }
+  }
+`;

--- a/src/components/domain/ManageGroup/ManageMember.jsx
+++ b/src/components/domain/ManageGroup/ManageMember.jsx
@@ -2,51 +2,53 @@ import { Header, Icon, SearchBar } from '@/components/base';
 import { Member, MemberList } from '@/components/domain/groupInfo';
 import * as S from '@/components/domain/ManageGroup/styles';
 import { useGroupContext } from '@/context/GroupProvider';
+import { useToastContext } from '@/context/ToastProvider';
 import useInput from '@/hooks/useInput';
 import { COLOR } from '@/styles/color';
 import styled from '@emotion/styled';
+import { useNavigate } from 'react-router-dom';
 
-const TOAST_MESSAGE = {
+const MESSAGE = {
   ALERT_MEMBER_KICK: '이 강퇴 되었습니다.',
   ALERT_MASTER_DELEGATE: '이 방장이 되었습니다.',
   CONFIRM_MEMBER_KICK: '을 정말 강퇴하시겠습니까?',
   CONFIRM_MASTER_DELEGATE: '에게 방장을 위임하시겠습니까?',
 };
 
-function ManageMember({ member }) {
+function ManageMember({ group, setGroup, member }) {
   const { onUpdateGroup } = useGroupContext();
+  const { addToast } = useToastContext();
   const { value, onChange } = useInput('');
+  const navigate = useNavigate();
 
-  const handleKickClick = async (member) => {
-    const { fullName, _id } = member;
-    if (!confirm(`'${fullName}'님${TOAST_MESSAGE.CONFIRM_MEMBER_KICK}`)) return false;
-    const data = {
-      ...group,
-      description: JSON.stringify({
-        ...group.description,
-        member: group.description.member.filter((memberId) => memberId !== _id),
-      }),
-    };
-    const updatedGroup = await onUpdateGroup(data);
-    setGroup(updatedGroup);
-    addToast(`'${fullName}님'${TOAST_MESSAGE.ALERT_MEMBER_KICK}`);
+  const featureNames = {
+    k: 'MEMBER_KICK',
+    d: 'MASTER_DELEGATE',
   };
 
-  const handleDelegateClick = async (member) => {
+  const handleMember = async (member, feat) => {
+    const confirm = `CONFIRM_${featureNames[feat]}`;
+    const alert = `ALERT_${featureNames[feat]}`;
     const { fullName, _id } = member;
-    if (!confirm(`'${fullName}'님${TOAST_MESSAGE.CONFIRM_MASTER_DELEGATE}`)) return false;
-    const data = {
+    if (!window.confirm(`'${fullName}'님${MESSAGE[confirm]}`)) return false;
+
+    const updatedMember =
+      feat === 'k'
+        ? { member: group.description.member.filter((memberId) => memberId !== _id) }
+        : {
+            master: _id,
+            member: [...group.description.member.filter((memberId) => memberId !== _id), group.description.master],
+          };
+    const updatedGroup = {
       ...group,
       description: JSON.stringify({
         ...group.description,
-        master: _id,
-        member: [...group.description.member.filter((memberId) => memberId !== _id), group.description.master],
+        ...updatedMember,
       }),
     };
-    const updatedGroup = await onUpdateGroup(data);
-    setGroup(updatedGroup);
-    addToast(`'${fullName}님'${TOAST_MESSAGE.ALERT_MASTER_DELEGATE}`);
-    navigate('/myGroup');
+    setGroup(await onUpdateGroup(updatedGroup));
+    addToast(`'${fullName}'님${MESSAGE[alert]}`);
+    feat === 'd' && navigate('/myGroup');
   };
 
   return (
@@ -71,8 +73,8 @@ function ManageMember({ member }) {
               return (
                 <Member key={member._id} image={member.image} fullName={member.fullName}>
                   <div>
-                    <Icon name='right-to-bracket' size={2} onClick={() => handleKickClick(member)} />
-                    <Icon name='crown' size={2} onClick={() => handleDelegateClick(member)} />
+                    <Icon name='right-to-bracket' size={2} onClick={() => handleMember(member, 'k')} />
+                    <Icon name='crown' size={2} onClick={() => handleMember(member, 'd')} />
                   </div>
                 </Member>
               );

--- a/src/components/domain/ManageGroup/ManageMember.jsx
+++ b/src/components/domain/ManageGroup/ManageMember.jsx
@@ -2,18 +2,15 @@ import { Header, Icon, SearchBar } from '@/components/base';
 import { Member, MemberList } from '@/components/domain/groupInfo';
 import { useGroupContext } from '@/context/GroupProvider';
 import useInput from '@/hooks/useInput';
+import { StyledGroupBox, StyledGroupInfo } from '@/pages/ManageGroup';
 import { COLOR } from '@/styles/color';
 import styled from '@emotion/styled';
-import { StyledGroupBox, StyledGroupInfo } from '@/pages/ManageGroup';
 
-const ALERT_MESSAGE = {
-  MEMBER_KICK: '이 강퇴 되었습니다.',
-  MASTER_DELEGATE: '이 방장이 되었습니다.',
-};
-
-const CONFIRM_MESSAGE = {
-  MEMBER_KICK: '을 정말 강퇴하시겠습니까?',
-  MASTER_DELEGATE: '에게 방장을 위임하시겠습니까?',
+const TOAST_MESSAGE = {
+  ALERT_MEMBER_KICK: '이 강퇴 되었습니다.',
+  ALERT_MASTER_DELEGATE: '이 방장이 되었습니다.',
+  CONFIRM_MEMBER_KICK: '을 정말 강퇴하시겠습니까?',
+  CONFIRM_MASTER_DELEGATE: '에게 방장을 위임하시겠습니까?',
 };
 
 function ManageMember({ member }) {
@@ -22,7 +19,7 @@ function ManageMember({ member }) {
 
   const handleKickClick = async (member) => {
     const { fullName, _id } = member;
-    if (!confirm(`'${fullName}'님${CONFIRM_MESSAGE.MEMBER_KICK}`)) return false;
+    if (!confirm(`'${fullName}'님${TOAST_MESSAGE.CONFIRM_MEMBER_KICK}`)) return false;
     const data = {
       ...group,
       description: JSON.stringify({
@@ -32,12 +29,12 @@ function ManageMember({ member }) {
     };
     const updatedGroup = await onUpdateGroup(data);
     setGroup(updatedGroup);
-    addToast(`'${fullName}님'${ALERT_MESSAGE.MEMBER_KICK}`);
+    addToast(`'${fullName}님'${TOAST_MESSAGE.ALERT_MEMBER_KICK}`);
   };
 
   const handleDelegateClick = async (member) => {
     const { fullName, _id } = member;
-    if (!confirm(`'${fullName}'님${CONFIRM_MESSAGE.MASTER_DELEGATE}`)) return false;
+    if (!confirm(`'${fullName}'님${TOAST_MESSAGE.CONFIRM_MASTER_DELEGATE}`)) return false;
     const data = {
       ...group,
       description: JSON.stringify({
@@ -48,7 +45,7 @@ function ManageMember({ member }) {
     };
     const updatedGroup = await onUpdateGroup(data);
     setGroup(updatedGroup);
-    addToast(`'${fullName}님'${ALERT_MESSAGE.MASTER_DELEGATE}`);
+    addToast(`'${fullName}님'${TOAST_MESSAGE.ALERT_MASTER_DELEGATE}`);
     navigate('/myGroup');
   };
 

--- a/src/components/domain/ManageGroup/ManageMember.jsx
+++ b/src/components/domain/ManageGroup/ManageMember.jsx
@@ -1,8 +1,8 @@
 import { Header, Icon, SearchBar } from '@/components/base';
 import { Member, MemberList } from '@/components/domain/groupInfo';
+import * as S from '@/components/domain/ManageGroup/styles';
 import { useGroupContext } from '@/context/GroupProvider';
 import useInput from '@/hooks/useInput';
-import { StyledGroupBox, StyledGroupInfo } from '@/pages/ManageGroup';
 import { COLOR } from '@/styles/color';
 import styled from '@emotion/styled';
 
@@ -54,7 +54,7 @@ function ManageMember({ member }) {
       <Header level={3} size={25}>
         그룹원 관리
       </Header>
-      <StyledGroupInfo>
+      <S.GroupInfo>
         <SearchBar
           placeholder='찾고 싶은 그룹원의 이름을 검색하세요.'
           value={value}
@@ -62,7 +62,7 @@ function ManageMember({ member }) {
           iconProps={{ size: 2, style: { color: `${COLOR.DARK}` } }}
           style={{ fontSize: '1.8rem', fontWeight: 100, borderBottom: `0.1rem solid ${COLOR.GRAY}` }}
         />
-      </StyledGroupInfo>
+      </S.GroupInfo>
       <MemberList>
         {member &&
           member
@@ -84,7 +84,7 @@ function ManageMember({ member }) {
 
 export default ManageMember;
 
-const StyledManageMember = styled(StyledGroupBox)`
+const StyledManageMember = styled(S.GroupBox)`
   & > div {
     overflow-y: auto;
   }

--- a/src/components/domain/ManageGroup/UpdateGroupInfo.jsx
+++ b/src/components/domain/ManageGroup/UpdateGroupInfo.jsx
@@ -23,7 +23,7 @@ function UpdateGroupInfo({ group, setGroup }) {
 
   useEffect(() => {
     if (group) {
-      const { headCount: memberCount, tagList: tags, intro: introduction } = group.description
+      const { headCount: memberCount, tagList: tags, intro: introduction } = group.description;
       groupName.onChange(group.name);
       headCount.onChange(memberCount);
       intro.onChange(introduction);
@@ -45,9 +45,11 @@ function UpdateGroupInfo({ group, setGroup }) {
       addToast(ALERT_MESSAGE.GROUP_TAG);
       return false;
     }
+    return true;
   };
 
   const handleSubmit = async () => {
+    console.log('inputValidate', inputValidate());
     if (!inputValidate()) return false;
 
     const updatedGroup = await onUpdateGroup({

--- a/src/components/domain/ManageGroup/UpdateGroupInfo.jsx
+++ b/src/components/domain/ManageGroup/UpdateGroupInfo.jsx
@@ -1,0 +1,115 @@
+import * as S from '@/components/domain/ManageGroup/styles';
+import { Header, Input, TagInput, Text, Textarea } from '@/components/base';
+import { useGroupContext } from '@/context/GroupProvider';
+import { useToastContext } from '@/context/ToastProvider';
+import useInput from '@/hooks/useInput';
+import { useEffect } from 'react';
+
+const ALERT_MESSAGE = {
+  GROUP_NAME: '그룹명은 한 글자 이상이어야 합니다.',
+  GROUP_HEAD_COUNT_1: '그룹 인원은 최소 2명 이상이어야 합니다.',
+  GROUP_HEAD_COUNT_2: '그룹의 최대 인원은 현재 그룹 인원보다 많아야 합니다.',
+  GROUP_TAG: '태그는 최소 1개 이상이어야 합니다.',
+  GROUP_UPDATE: '그룹 정보가 수정되었습니다.',
+};
+
+function UpdateGroupInfo({ group, setGroup }) {
+  const { onUpdateGroup } = useGroupContext();
+  const { addToast } = useToastContext();
+  const groupName = useInput('');
+  const headCount = useInput(0);
+  const intro = useInput('');
+  const tagList = useInput([]);
+
+  useEffect(() => {
+    if (group) {
+      const { headCount: memberCount, tagList: tags, intro: introduction } = group.description
+      groupName.onChange(group.name);
+      headCount.onChange(memberCount);
+      intro.onChange(introduction);
+      tagList.onChange(tags);
+    }
+  }, [group]);
+
+  const inputValidate = () => {
+    if (groupName.value === '') {
+      addToast(ALERT_MESSAGE.GROUP_NAME);
+      return false;
+    } else if (headCount.value < 2) {
+      addToast(ALERT_MESSAGE.GROUP_HEAD_COUNT_1);
+      return false;
+    } else if (headCount.value < group.description.member.length + 1) {
+      addToast(ALERT_MESSAGE.GROUP_HEAD_COUNT_2);
+      return false;
+    } else if (tagList.value.length === 0) {
+      addToast(ALERT_MESSAGE.GROUP_TAG);
+      return false;
+    }
+  };
+
+  const handleSubmit = async () => {
+    if (!inputValidate()) return false;
+
+    const updatedGroup = await onUpdateGroup({
+      ...group,
+      name: groupName.value,
+      description: JSON.stringify({
+        ...group.description,
+        headCount: headCount.value,
+        tagList: tagList.value,
+        intro: intro.value,
+      }),
+    });
+    setGroup(updatedGroup);
+    addToast(ALERT_MESSAGE.GROUP_UPDATE);
+  };
+
+  return (
+    <S.GroupBox>
+      <Header level={3} size={25}>
+        그룹 정보 관리
+      </Header>
+      <S.GroupInfo>
+        <Text block size={2}>
+          그룹명
+        </Text>
+        <Input type='text' value={groupName.value} onChange={groupName.onChange} max={15} block required />
+      </S.GroupInfo>
+      <S.GroupInfo>
+        <Text block size={2}>
+          최대 인원
+        </Text>
+        <Input
+          type='number'
+          block
+          label={`최대 2~50명`}
+          value={headCount.value}
+          onChange={headCount.onChange}
+          max={50}
+          required
+        />
+      </S.GroupInfo>
+      <S.GroupInfo>
+        <Text block size={2}>
+          태그
+        </Text>
+        <TagInput tagList={tagList.value} onChange={tagList.onChange} />
+      </S.GroupInfo>
+      <S.GroupInfo>
+        <Text block size={2}>
+          소개
+        </Text>
+        <Textarea
+          value={intro.value}
+          onChange={intro.onChange}
+          placeholder='그룹을 소개하는 글을 작성해주세요.'
+          max={300}
+          wrapperProps={{ style: { width: '100%' } }}
+        />
+      </S.GroupInfo>
+      <S.Button onClick={handleSubmit}>수정</S.Button>
+    </S.GroupBox>
+  );
+}
+
+export default UpdateGroupInfo;

--- a/src/components/domain/ManageGroup/index.jsx
+++ b/src/components/domain/ManageGroup/index.jsx
@@ -1,1 +1,2 @@
 export { default as ManageMember } from './ManageMember';
+export { default as GroupDelete } from './GroupDelete';

--- a/src/components/domain/ManageGroup/index.jsx
+++ b/src/components/domain/ManageGroup/index.jsx
@@ -1,2 +1,3 @@
 export { default as ManageMember } from './ManageMember';
 export { default as GroupDelete } from './GroupDelete';
+export { default as UpdateGroupInfo } from './UpdateGroupInfo';

--- a/src/components/domain/ManageGroup/index.jsx
+++ b/src/components/domain/ManageGroup/index.jsx
@@ -1,0 +1,1 @@
+export { default as ManageMember } from './ManageMember';

--- a/src/components/domain/ManageGroup/styles.jsx
+++ b/src/components/domain/ManageGroup/styles.jsx
@@ -1,0 +1,58 @@
+import { COLOR } from '@/styles/color';
+import styled from '@emotion/styled';
+
+export const GroupBox = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  width: 80rem;
+  padding: 2rem;
+  border-radius: 1rem;
+  background-color: ${COLOR.WHITE};
+
+  & > h3 {
+    margin-bottom: 1rem;
+    padding-bottom: 1rem;
+    border-bottom: 1px solid ${COLOR.GRAY_10};
+  }
+
+  & > div {
+    width: 45rem;
+  }
+`;
+
+export const GroupInfo = styled.div`
+  width: 100%;
+  padding: 2rem 0;
+
+  & input {
+    height: 3rem;
+    font-weight: 100;
+    font-size: 1.6rem;
+    color: ${COLOR.DARK};
+  }
+
+  & textarea {
+    height: 20rem;
+    border-radius: 0.5rem;
+    font-weight: 100;
+    font-size: 1.6rem;
+  }
+`;
+
+export const Button = styled.button`
+  width: 10rem;
+  padding: 1rem;
+  border-radius: 0.6rem;
+
+  background-color: ${COLOR.PRIMARY_BTN};
+  text-align: center;
+  font-size: 1.8rem;
+  color: ${COLOR.WHITE};
+  cursor: pointer;
+
+  &:hover {
+    opacity: 0.9;
+  }
+`;

--- a/src/pages/ManageGroup.jsx
+++ b/src/pages/ManageGroup.jsx
@@ -1,139 +1,39 @@
-import { Header, Input, TagInput, Text, Textarea } from '@/components/base';
-import { GroupDelete, ManageMember } from '@/components/domain/ManageGroup';
-import * as S from '@/components/domain/ManageGroup/styles';
+import { GroupDelete, ManageMember, UpdateGroupInfo } from '@/components/domain/ManageGroup';
 import { useGroupContext } from '@/context/GroupProvider';
-import { useToastContext } from '@/context/ToastProvider';
 import { useUserContext } from '@/context/UserProvider';
-import useInput from '@/hooks/useInput';
 import { COLOR } from '@/styles/color';
 import styled from '@emotion/styled';
 import { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 
-const ALERT_MESSAGE = {
-  GROUP_NAME: '그룹명은 한 글자 이상이어야 합니다.',
-  GROUP_HEAD_COUNT_1: '그룹 인원은 최소 2명 이상이어야 합니다.',
-  GROUP_HEAD_COUNT_2: '그룹의 최대 인원은 현재 그룹 인원보다 많아야 합니다.',
-  GROUP_TAG: '태그는 최소 1개 이상이어야 합니다.',
-  GROUP_UPDATE: '그룹 정보가 수정되었습니다.',
-};
-
 function ManageGroup() {
   const {
     state: { _id },
   } = useLocation();
-  const { groups, onUpdateGroup } = useGroupContext();
-  const { addToast } = useToastContext();
-  const [group, setGroup] = useState();
-  const groupName = useInput('');
-  const headCount = useInput(0);
-  const intro = useInput('');
-  const tagList = useInput([]);
+  const { groups } = useGroupContext();
   const { users } = useUserContext();
+  const [group, setGroup] = useState();
+  const [member, setMember] = useState();
 
   useEffect(() => {
     groups.value && setGroup(...groups.value.filter((group) => group._id === _id));
   }, [groups]);
 
-  const [member, setMember] = useState();
-
   useEffect(() => {
     const getMemberInfo = (members) => {
       return users?.filter((user) => members.includes(user._id));
     };
-
     if (group && users) {
-      const { headCount: memberCount, tagList: tags, intro: introduction, member } = group.description;
-      setMember(getMemberInfo(member));
-      groupName.onChange(group.name);
-      headCount.onChange(memberCount);
-      intro.onChange(introduction);
-      tagList.onChange(tags);
+      setMember(getMemberInfo(group.description.member));
     }
   }, [group, users]);
-
-  const inputValidate = () => {
-    if (groupName.value === '') {
-      addToast(ALERT_MESSAGE.GROUP_NAME);
-      return false;
-    } else if (headCount.value < 2) {
-      addToast(ALERT_MESSAGE.GROUP_HEAD_COUNT_1);
-      return false;
-    } else if (headCount.value < group.description.member.length + 1) {
-      addToast(ALERT_MESSAGE.GROUP_HEAD_COUNT_2);
-      return false;
-    } else if (tagList.value.length === 0) {
-      addToast(ALERT_MESSAGE.GROUP_TAG);
-      return false;
-    }
-  };
-
-  const handleSubmit = async () => {
-    if (!inputValidate()) return false;
-
-    const updatedGroup = await onUpdateGroup({
-      ...group,
-      name: groupName.value,
-      description: JSON.stringify({
-        ...group.description,
-        headCount: headCount.value,
-        tagList: tagList.value,
-        intro: intro.value,
-      }),
-    });
-    setGroup(updatedGroup);
-    addToast(ALERT_MESSAGE.GROUP_UPDATE);
-  };
 
   if (!group) return;
 
   return (
     <StyledPageWrapper>
       <StyledManageGroup>
-        <S.GroupBox>
-          <Header level={3} size={25}>
-            그룹 정보 관리
-          </Header>
-          <S.GroupInfo>
-            <Text block size={2}>
-              그룹명
-            </Text>
-            <Input type='text' value={groupName.value} onChange={groupName.onChange} max={15} block required />
-          </S.GroupInfo>
-          <S.GroupInfo>
-            <Text block size={2}>
-              최대 인원
-            </Text>
-            <Input
-              type='number'
-              block
-              label={`최대 2~50명`}
-              value={headCount.value}
-              onChange={headCount.onChange}
-              max={50}
-              required
-            />
-          </S.GroupInfo>
-          <S.GroupInfo>
-            <Text block size={2}>
-              태그
-            </Text>
-            <TagInput tagList={tagList.value} onChange={tagList.onChange} />
-          </S.GroupInfo>
-          <S.GroupInfo>
-            <Text block size={2}>
-              소개
-            </Text>
-            <Textarea
-              value={intro.value}
-              onChange={intro.onChange}
-              placeholder='그룹을 소개하는 글을 작성해주세요.'
-              max={300}
-              wrapperProps={{ style: { width: '100%' } }}
-            />
-          </S.GroupInfo>
-          <S.Button onClick={handleSubmit}>수정</S.Button>
-        </S.GroupBox>
+        <UpdateGroupInfo group={group} setGroup={setGroup} />
         <ManageMember group={group} setGroup={setGroup} member={member} />
         <GroupDelete groupId={group._id} />
       </StyledManageGroup>

--- a/src/pages/ManageGroup.jsx
+++ b/src/pages/ManageGroup.jsx
@@ -1,4 +1,6 @@
 import { Header, Input, TagInput, Text, Textarea } from '@/components/base';
+import { GroupDelete, ManageMember } from '@/components/domain/ManageGroup';
+import * as S from '@/components/domain/ManageGroup/styles';
 import { useGroupContext } from '@/context/GroupProvider';
 import { useToastContext } from '@/context/ToastProvider';
 import { useUserContext } from '@/context/UserProvider';
@@ -7,7 +9,6 @@ import { COLOR } from '@/styles/color';
 import styled from '@emotion/styled';
 import { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
-import { GroupDelete, ManageMember } from '@/components/domain/ManageGroup';
 
 const ALERT_MESSAGE = {
   GROUP_NAME: '그룹명은 한 글자 이상이어야 합니다.',
@@ -89,17 +90,17 @@ function ManageGroup() {
   return (
     <StyledPageWrapper>
       <StyledManageGroup>
-        <StyledGroupBox>
+        <S.GroupBox>
           <Header level={3} size={25}>
             그룹 정보 관리
           </Header>
-          <StyledGroupInfo>
+          <S.GroupInfo>
             <Text block size={2}>
               그룹명
             </Text>
             <Input type='text' value={groupName.value} onChange={groupName.onChange} max={15} block required />
-          </StyledGroupInfo>
-          <StyledGroupInfo>
+          </S.GroupInfo>
+          <S.GroupInfo>
             <Text block size={2}>
               최대 인원
             </Text>
@@ -112,14 +113,14 @@ function ManageGroup() {
               max={50}
               required
             />
-          </StyledGroupInfo>
-          <StyledGroupInfo>
+          </S.GroupInfo>
+          <S.GroupInfo>
             <Text block size={2}>
               태그
             </Text>
             <TagInput tagList={tagList.value} onChange={tagList.onChange} />
-          </StyledGroupInfo>
-          <StyledGroupInfo>
+          </S.GroupInfo>
+          <S.GroupInfo>
             <Text block size={2}>
               소개
             </Text>
@@ -130,9 +131,9 @@ function ManageGroup() {
               max={300}
               wrapperProps={{ style: { width: '100%' } }}
             />
-          </StyledGroupInfo>
-          <StyledButton onClick={handleSubmit}>수정</StyledButton>
-        </StyledGroupBox>
+          </S.GroupInfo>
+          <S.Button onClick={handleSubmit}>수정</S.Button>
+        </S.GroupBox>
         <ManageMember member={member} />
         <GroupDelete />
       </StyledManageGroup>
@@ -158,60 +159,4 @@ const StyledManageGroup = styled.div`
   flex: 1;
   padding: 10rem;
   background-color: ${COLOR.MY_GROUP_BG};
-`;
-
-export const StyledGroupBox = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-
-  width: 80rem;
-  padding: 2rem;
-  border-radius: 1rem;
-  background-color: ${COLOR.WHITE};
-
-  & > h3 {
-    margin-bottom: 1rem;
-    padding-bottom: 1rem;
-    border-bottom: 1px solid ${COLOR.GRAY_10};
-  }
-
-  & > div {
-    width: 45rem;
-  }
-`;
-
-export const StyledGroupInfo = styled.div`
-  width: 100%;
-  padding: 2rem 0;
-
-  & input {
-    height: 3rem;
-    font-weight: 100;
-    font-size: 1.6rem;
-    color: ${COLOR.DARK};
-  }
-
-  & textarea {
-    height: 20rem;
-    border-radius: 0.5rem;
-    font-weight: 100;
-    font-size: 1.6rem;
-  }
-`;
-
-export const StyledButton = styled.button`
-  width: 10rem;
-  padding: 1rem;
-  border-radius: 0.6rem;
-
-  background-color: ${COLOR.PRIMARY_BTN};
-  text-align: center;
-  font-size: 1.8rem;
-  color: ${COLOR.WHITE};
-  cursor: pointer;
-
-  &:hover {
-    opacity: 0.9;
-  }
 `;

--- a/src/pages/ManageGroup.jsx
+++ b/src/pages/ManageGroup.jsx
@@ -6,8 +6,8 @@ import useInput from '@/hooks/useInput';
 import { COLOR } from '@/styles/color';
 import styled from '@emotion/styled';
 import { useEffect, useState } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
-import { ManageMember } from '../components/domain/ManageGroup';
+import { useLocation } from 'react-router-dom';
+import { GroupDelete, ManageMember } from '@/components/domain/ManageGroup';
 
 const ALERT_MESSAGE = {
   GROUP_NAME: '그룹명은 한 글자 이상이어야 합니다.',
@@ -15,15 +15,6 @@ const ALERT_MESSAGE = {
   GROUP_HEAD_COUNT_2: '그룹의 최대 인원은 현재 그룹 인원보다 많아야 합니다.',
   GROUP_TAG: '태그는 최소 1개 이상이어야 합니다.',
   GROUP_UPDATE: '그룹 정보가 수정되었습니다.',
-  GROUP_DELETE: '그룹이 삭제되었습니다.',
-  MEMBER_KICK: '이 강퇴 되었습니다.',
-  MASTER_DELEGATE: '이 방장이 되었습니다.',
-};
-
-const CONFIRM_MESSAGE = {
-  GROUP_DELETE: '정말 그룹을 삭제하시겠습니까?',
-  MEMBER_KICK: '을 정말 강퇴하시겠습니까?',
-  MASTER_DELEGATE: '에게 방장을 위임하시겠습니까?',
 };
 
 function ManageGroup() {
@@ -37,7 +28,6 @@ function ManageGroup() {
   const headCount = useInput(0);
   const intro = useInput('');
   const tagList = useInput([]);
-  const navigate = useNavigate();
   const { users } = useUserContext();
 
   useEffect(() => {
@@ -94,15 +84,6 @@ function ManageGroup() {
     addToast(ALERT_MESSAGE.GROUP_UPDATE);
   };
 
-  const handleDeleteClick = async () => {
-    if (!confirm(CONFIRM_MESSAGE.GROUP_DELETE)) return;
-    await onDeleteGroup({
-      id: group._id,
-    });
-    addToast(ALERT_MESSAGE.GROUP_DELETE);
-    navigate('/myGroup');
-  };
-
   if (!group) return;
 
   return (
@@ -153,15 +134,7 @@ function ManageGroup() {
           <StyledButton onClick={handleSubmit}>수정</StyledButton>
         </StyledGroupBox>
         <ManageMember member={member} />
-        <StyledGroupDelete>
-          <Header level={3} size={25}>
-            그룹 삭제
-          </Header>
-          <Text paragraph strong size={1.6}>
-            한번 그룹을 삭제하면 다시 되돌릴 수 없습니다.
-          </Text>
-          <StyledDeleteButton onClick={handleDeleteClick}>삭제</StyledDeleteButton>
-        </StyledGroupDelete>
+        <GroupDelete />
       </StyledManageGroup>
     </StyledPageWrapper>
   );
@@ -187,7 +160,7 @@ const StyledManageGroup = styled.div`
   background-color: ${COLOR.MY_GROUP_BG};
 `;
 
-const StyledGroupBox = styled.div`
+export const StyledGroupBox = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -208,7 +181,7 @@ const StyledGroupBox = styled.div`
   }
 `;
 
-const StyledGroupInfo = styled.div`
+export const StyledGroupInfo = styled.div`
   width: 100%;
   padding: 2rem 0;
 
@@ -227,7 +200,7 @@ const StyledGroupInfo = styled.div`
   }
 `;
 
-const StyledButton = styled.button`
+export const StyledButton = styled.button`
   width: 10rem;
   padding: 1rem;
   border-radius: 0.6rem;
@@ -240,37 +213,5 @@ const StyledButton = styled.button`
 
   &:hover {
     opacity: 0.9;
-  }
-`;
-
-const StyledGroupDelete = styled(StyledGroupBox)`
-  background-color: ${COLOR.MY_GROUP_BOX_BG};
-
-  & > h3 {
-    border-bottom: 1px solid ${COLOR.RED_20};
-    color: ${COLOR.RED_20};
-  }
-
-  & > p {
-    padding: 1rem 0;
-  }
-`;
-
-const StyledDeleteButton = styled(StyledButton)`
-  margin-top: 1rem;
-  background-color: ${COLOR.RED_20};
-`;
-
-const StyledManageMember = styled(StyledGroupBox)`
-  & > div {
-    overflow-y: auto;
-  }
-
-  & i {
-    color: ${COLOR.PRIMARY_BTN};
-    &:hover {
-      color: ${COLOR.WHITE};
-      cursor: pointer;
-    }
   }
 `;

--- a/src/pages/ManageGroup.jsx
+++ b/src/pages/ManageGroup.jsx
@@ -22,7 +22,7 @@ function ManageGroup() {
   const {
     state: { _id },
   } = useLocation();
-  const { groups, onUpdateGroup, onDeleteGroup } = useGroupContext();
+  const { groups, onUpdateGroup } = useGroupContext();
   const { addToast } = useToastContext();
   const [group, setGroup] = useState();
   const groupName = useInput('');
@@ -134,8 +134,8 @@ function ManageGroup() {
           </S.GroupInfo>
           <S.Button onClick={handleSubmit}>수정</S.Button>
         </S.GroupBox>
-        <ManageMember member={member} />
-        <GroupDelete />
+        <ManageMember group={group} setGroup={setGroup} member={member} />
+        <GroupDelete groupId={group._id} />
       </StyledManageGroup>
     </StyledPageWrapper>
   );


### PR DESCRIPTION
## ⛓ 관련 이슈
- close #111

## 📝 작업 내용
- [x] 그룹 정보 변경 없을 경우 수정 버튼 비활성화
- [x] ManageGroup 컴포넌트 세부 컴포넌트로 분리

## 📍 PR Point
- 공통, 상속받는 스타일 컴포넌트들이 있어서 어떻게 할지 고민하다가 styles.jsx로 따로 뺐는데 다들 어떻게 생각하시나요?