### PR TITLE
[fix] TIL카드에 마크다운 표시되던 문제 수정

### DIFF
--- a/src/components/domain/TILItem/index.jsx
+++ b/src/components/domain/TILItem/index.jsx
@@ -4,7 +4,7 @@ import { cleanText } from '@/utils/cleanText';
 
 import { Link } from 'react-router-dom';
 
-import { COLOR } from '@/styles/color';
+import theme from '@/styles/theme';
 import { StyledDate, StyledPlusButton, StyledTag, StyledTagList, StyledTILContent, StyledTILItem } from './styles';
 
 function TILItem({ til }) {
@@ -16,7 +16,7 @@ function TILItem({ til }) {
   return (
     <StyledTILItem>
       <StyledDate>
-        <Text paragraph size='small' weight={300} color={COLOR.DARK}>
+        <Text paragraph size='small' weight={300} color={theme.colors.black_800}>
           {createdAt.slice(0, 10)}
         </Text>
       </StyledDate>
@@ -24,7 +24,7 @@ function TILItem({ til }) {
         <Text paragraph size='xxLarge' weight={600}>
           {title}
         </Text>
-        <Text paragraph size='large' weight={300} color={COLOR.DARK}>
+        <Text paragraph size='large' weight={300} color={theme.colors.black_800}>
           {cleanText(body)}
         </Text>
         <StyledTagList>

--- a/src/components/domain/TILItem/index.jsx
+++ b/src/components/domain/TILItem/index.jsx
@@ -1,7 +1,10 @@
 import { Text } from '@/components/base';
-import { COLOR } from '@/styles/color';
+
 import { cleanText } from '@/utils/cleanText';
+
 import { Link } from 'react-router-dom';
+
+import { COLOR } from '@/styles/color';
 import { StyledDate, StyledPlusButton, StyledTag, StyledTagList, StyledTILContent, StyledTILItem } from './styles';
 
 function TILItem({ til }) {

--- a/src/components/domain/TILItem/index.jsx
+++ b/src/components/domain/TILItem/index.jsx
@@ -1,5 +1,6 @@
 import { Text } from '@/components/base';
 import { COLOR } from '@/styles/color';
+import { cleanText } from '@/utils/cleanText';
 import { Link } from 'react-router-dom';
 import { StyledDate, StyledPlusButton, StyledTag, StyledTagList, StyledTILContent, StyledTILItem } from './styles';
 
@@ -21,7 +22,7 @@ function TILItem({ til }) {
           {title}
         </Text>
         <Text paragraph size='large' weight={300} color={COLOR.DARK}>
-          {body}
+          {cleanText(body)}
         </Text>
         <StyledTagList>
           {tagList?.map((tag) => (

--- a/src/components/domain/TILItem/index.jsx
+++ b/src/components/domain/TILItem/index.jsx
@@ -5,7 +5,7 @@ import { cleanText } from '@/utils/cleanText';
 import { Link } from 'react-router-dom';
 
 import theme from '@/styles/theme';
-import { StyledDate, StyledPlusButton, StyledTag, StyledTagList, StyledTILContent, StyledTILItem } from './styles';
+import * as S from './styles';
 
 function TILItem({ til }) {
   const {
@@ -14,31 +14,31 @@ function TILItem({ til }) {
   } = til;
 
   return (
-    <StyledTILItem>
-      <StyledDate>
+    <S.TILItem>
+      <S.Date>
         <Text paragraph size='small' weight={300} color={theme.colors.black_800}>
           {createdAt.slice(0, 10)}
         </Text>
-      </StyledDate>
-      <StyledTILContent>
+      </S.Date>
+      <S.TILContent>
         <Text paragraph size='xxLarge' weight={600}>
           {title}
         </Text>
         <Text paragraph size='large' weight={300} color={theme.colors.black_800}>
           {cleanText(body)}
         </Text>
-        <StyledTagList>
+        <S.TagList>
           {tagList?.map((tag) => (
-            <StyledTag key={tag}>{tag}</StyledTag>
+            <S.Tag key={tag}>{tag}</S.Tag>
           ))}
-        </StyledTagList>
-      </StyledTILContent>
+        </S.TagList>
+      </S.TILContent>
       <Link to={`/TIL/${til._id}`}>
-        <StyledPlusButton>
+        <S.PlusButton>
           <i className='fa-solid fa-plus'></i>
-        </StyledPlusButton>
+        </S.PlusButton>
       </Link>
-    </StyledTILItem>
+    </S.TILItem>
   );
 }
 

--- a/src/components/domain/TILItem/index.jsx
+++ b/src/components/domain/TILItem/index.jsx
@@ -1,6 +1,6 @@
 import { Text } from '@/components/base';
 
-import { cleanText } from '@/utils/cleanText';
+import { cleanMarkdown } from '@/utils/cleanMarkdown';
 
 import { Link } from 'react-router-dom';
 
@@ -25,7 +25,7 @@ function TILItem({ til }) {
           {title}
         </Text>
         <Text paragraph size='large' weight={300} color={theme.colors.black_800}>
-          {cleanText(body)}
+          {cleanMarkdown(body)}
         </Text>
         <S.TagList>
           {tagList?.map((tag) => (

--- a/src/components/domain/TILItem/styles.js
+++ b/src/components/domain/TILItem/styles.js
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-const StyledTILItem = styled.div`
+export const TILItem = styled.div`
   position: relative;
 
   width: 22rem;
@@ -16,12 +16,12 @@ const StyledTILItem = styled.div`
   }
 `;
 
-const StyledDate = styled.div`
+export const Date = styled.div`
   padding-bottom: 0.5rem;
   text-align: right;
 `;
 
-const StyledTILContent = styled.div`
+export const TILContent = styled.div`
   display: flex;
   flex-direction: column;
   gap: 1rem;
@@ -46,7 +46,7 @@ const StyledTILContent = styled.div`
   }
 `;
 
-const StyledPlusButton = styled.div`
+export const PlusButton = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
@@ -71,13 +71,13 @@ const StyledPlusButton = styled.div`
   }
 `;
 
-const StyledTagList = styled.div`
+export const TagList = styled.div`
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem 1rem;
 `;
 
-const StyledTag = styled.div`
+export const Tag = styled.div`
   min-width: fit-content;
   padding: 0.5rem;
   border-radius: 1rem;
@@ -85,5 +85,3 @@ const StyledTag = styled.div`
   box-shadow: 0 0.1rem 0.4rem ${({ theme }) => theme.shadows[900]};
   font-size: 1.2rem;
 `;
-
-export { StyledTILItem, StyledDate, StyledTILContent, StyledPlusButton, StyledTagList, StyledTag };

--- a/src/components/domain/TILItem/styles.js
+++ b/src/components/domain/TILItem/styles.js
@@ -1,5 +1,4 @@
 import styled from '@emotion/styled';
-import { COLOR } from '@/styles/color';
 
 const StyledTILItem = styled.div`
   position: relative;
@@ -8,9 +7,9 @@ const StyledTILItem = styled.div`
   height: 28rem;
   padding: 1.2rem;
   border-radius: 1rem;
-  background-color: ${COLOR.CARD_BG};
-  box-shadow: 0 0.1rem 0.4rem ${COLOR.SHADOW};
-  color: ${COLOR.DARK};
+  background-color: ${({ theme }) => theme.colors.white_600};
+  box-shadow: 0 0.1rem 0.4rem ${({ theme }) => theme.shadows[900]};
+  color: ${({ theme }) => theme.colors.black_800};
 
   & > p:nth-of-type(2) {
     word-break: break-all;
@@ -57,13 +56,13 @@ const StyledPlusButton = styled.div`
 
   width: 5rem;
   height: 5rem;
-  border-top: 0.3rem solid ${COLOR.GRAY_20};
-  border-left: 0.3rem solid ${COLOR.GRAY_20};
+  border-top: 0.3rem solid ${({ theme }) => theme.shadows[600]};
+  border-left: 0.3rem solid ${({ theme }) => theme.shadows[600]};
   border-radius: 1rem 0;
-  background-color: ${COLOR.TAG_COLOR[0]};
+  background-color: ${({ theme }) => theme.colors.TAG_COLOR[0]};
 
   font-size: 2.5rem;
-  color: white;
+  color: ${({ theme }) => theme.colors.white_900};
   cursor: pointer;
   transition: background-color 0.2s ease-in;
 
@@ -83,7 +82,7 @@ const StyledTag = styled.div`
   padding: 0.5rem;
   border-radius: 1rem;
   background-color: white;
-  box-shadow: 0 0.1rem 0.4rem ${COLOR.SHADOW};
+  box-shadow: 0 0.1rem 0.4rem ${({ theme }) => theme.shadows[900]};
   font-size: 1.2rem;
 `;
 

--- a/src/utils/cleanMarkdown.js
+++ b/src/utils/cleanMarkdown.js
@@ -1,0 +1,12 @@
+export const cleanMarkdown = (markdownText) => {
+  const cleanText = markdownText
+    .replace(/!\[([^\]]+)\]\([^)]+\)/g, '$1') // Remove image syntax
+    .replace(/\[(.*?)\]\((.*?)\)/g, '$1') // Remove link syntax
+    .replace(/^>\s*(.*)$/gm, '$1') // Remove blockQuote syntax
+    .replace(/<\/?[^>]+(>|$)/g, '') // Remove Raw HTML syntax
+    .replace(/^#+\s+(.*)$/gm, '$1') // Remove heading syntax
+    .replace(/(\*\*|__|\*|_)(.*?)\1/g, '$2') // Remove bold and italic syntax
+    .replace(/(\*\*|~~)(.*?)\1/g, '$2'); // Remove tilde syntax
+
+  return cleanText;
+};

--- a/src/utils/cleanText.js
+++ b/src/utils/cleanText.js
@@ -1,0 +1,3 @@
+export const cleanText = (markdownText) => {
+  return markdownText.replace(/<\/?[^>]+(>|$)/g, '');
+};

--- a/src/utils/cleanText.js
+++ b/src/utils/cleanText.js
@@ -1,3 +1,0 @@
-export const cleanText = (markdownText) => {
-  return markdownText.replace(/<\/?[^>]+(>|$)/g, '');
-};


### PR DESCRIPTION
## ⛓ 관련 이슈
- close #154 

## 📝 작업 내용
- [x] html태그를 제거할 cleanText 유틸함수 작성
- [x] TILItem에 cleanText 반영

## 📍 PR Point
cleanText로 유틸함수 이름을 짓긴했는데
약간 추상적인 느낌이 있어서.. 좀더 직관적인 이름이 떠오른다면
말해주셔도 좋습니다~~!

일단 생각해본 이름들
- cleanText
- cleanMarkdownText
- removeHtmlTags
...

## 📷 스크린샷
<img width="240" alt="Screen Shot 2023-04-17 at 2 42 50 PM" src="https://user-images.githubusercontent.com/73218463/232394900-4ecfe07d-7fae-446e-8255-b8915fe538e6.png">

<img width="232" alt="Screen Shot 2023-04-17 at 2 43 07 PM" src="https://user-images.githubusercontent.com/73218463/232394887-46798d7d-7d7a-48a4-9aee-9399ef776a6d.png">

